### PR TITLE
Update Makefile.am

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -78,5 +78,5 @@ EXTRA_DIST = 	refile_and_grok.sh.in \
 				hedgehog_rssac_rm_old_unique_source_data.sh.in 
 	
 install-data-hook:
-	mkdir -p $(localstatedir)/hedgehog
-	chmod -R 775 $(localstatedir)/hedgehog
+	mkdir -p ${DESTDIR}$(localstatedir)/hedgehog
+	chmod -R 775 ${DESTDIR}$(localstatedir)/hedgehog


### PR DESCRIPTION
Prepending the mkdir and chmod calls allows hedgehog to be built as non-root in chroot environments.