### PR TITLE
Update refile_and_grok.sh.in

### DIFF
--- a/tools/refile_and_grok.sh.in
+++ b/tools/refile_and_grok.sh.in
@@ -23,17 +23,17 @@
 # File: refile_and_grok.sh  
 #
 
-PROG=`basename "$0" .sh`
+PROG=$(basename "$0" .sh)
 
 eval $(@BIN@/hedgehog_conf_read.pl)
 
 set -e # exit if any command yields a non 0 exit status
-WD=$hhconfig_directories_data
+WD="$hhconfig_directories_data"
 INPUT="XML"
 OUTPUT="DB"
 CONNSTR="dbname=$hhconfig_database_name dbport=$hhconfig_database_port"
 START_DATE=""
-RSSAC_FLAG="";
+RSSAC_FLAG=""
 RESERVED_CPUS=0
 DB_NAME="$hhconfig_database_name"
 ARGS=""
@@ -56,7 +56,7 @@ usage () {
 
 
 while getopts ":w:i:o:cs:rR:h" opt; do
-    case $opt in
+    case "$opt" in
         w  ) WD=$OPTARG ;;
         i  ) INPUT=$OPTARG ;;
         o  ) OUTPUT=$OPTARG ;;
@@ -71,33 +71,30 @@ while getopts ":w:i:o:cs:rR:h" opt; do
     esac
 done
 
-[ $USER != $hhconfig_database_owner ] && echo "Must be $hhconfig_database_owner to run this script" && exit 1
+[ "$USER" != "$hhconfig_database_owner" ] && echo "Must be $hhconfig_database_owner to run this script." && exit 1
 
-DB_API_VERSION=`psql $DB_NAME  -tc  "select version from dsc.version;"`
-[ $DB_API_VERSION != $REQUIRED_API_VERSION ] && echo "Error: Database API version incorrect." && exit 1
+DB_API_VERSION=$(psql "$DB_NAME"  -tc  "select version from dsc.version;")
+[ "$DB_API_VERSION" != "$REQUIRED_API_VERSION" ] && echo "Error: Database API version incorrect." && exit 1
 
-if ! [[ $RESERVED_CPUS =~ ^[0-9]+$ ]] ; then
-	echo "Reserved CPUS ($RESERVED_CPUS) is not a positive number. Exiting"
+if ! [[ "$RESERVED_CPUS" =~ ^[0-9]+$ ]] ; then
+	echo "Reserved CPUS ($RESERVED_CPUS) is not a positive number. Exiting."
 	exit
 fi
 # Get number of real cores
-export REAL_CPUS=`lscpu | grep -i Socket | awk -F: ' { if (total==0) total=1; total=total * $2; print total } ' | tail -1`
-if [[ $RESERVED_CPUS -ge $REAL_CPUS ]] ; then
-	echo "Reserved CPUS ($RESERVED_CPUS) is greater than or equal to the number of available CPUS ($REAL_CPUS). Exiting.... "
+export REAL_CPUS=$(lscpu | awk -F: 'BEGIN { IGNORECASE=1; total=1 } /socket/ { total=total * $2 } END { print total }')
+if [ "$RESERVED_CPUS" -ge "$REAL_CPUS" ] ; then
+	echo "Reserved CPUS ($RESERVED_CPUS) is greater than or equal to the number of available CPUS ($REAL_CPUS). Exiting."
 	exit
 fi
 # This option allows some CPUS to be reserved for the web front end in the case that the import is running continuously
-CPUS=$((REAL_CPUS - RESERVED_CPUS ))
-echo "Using $CPUS CPUS. ($REAL_CPUS available, $RESERVED_CPUS reserved.)"
+CPUS=$(( REAL_CPUS - RESERVED_CPUS ))
+echo "Using $CPUS CPUS ($REAL_CPUS available, $RESERVED_CPUS reserved)."
 
 if [[ "$INPUT" = "XML" || "$INPUT" = "DAT" ]] && [ "$OUTPUT" = "DB" ]
 then
     ARGS="-i ${INPUT} -o PG_DB -c ${CONNSTR} ${START_DATE} ${RSSAC_FLAG}"
-    LOG=`echo "$LOG" | sed 's/.out/-xml-db.out/'`
-    if [ "$INPUT" == "DAT" ]
-    then
-        LOG=`echo "$LOG" | sed 's/xml/dat/'`
-    fi
+    LOG=${LOG/.out/-xml-db.out}
+    [ "$INPUT" == "DAT" ] && LOG=${LOG/xml/dat}
 fi
 
 
@@ -108,25 +105,22 @@ then
     echo "LOG = $LOG"
     echo -n "Would you like to continue? y/N: "
     read c
-    if [ "$c" != "Y" ] && [ "$c" != "y" ]
-    then
-        exit 1
-    fi
+    [[ "$c" =~ ^(Y|y) ]] && exit 1
 fi
 
 #set -x #Print commands just before execution - with all expansions and substitutions done, and words marked - useful for debugging.
 
 cd "${WD}"
-exec >$PROG.stdout
+exec >"$PROG.stdout"
 #exec 2>&1
 
-echo "`date`-->SCRIPT COMMENCED"
+echo "$(date) SCRIPT COMMENCED"
 EXECDIR=@BIN@
 export EXECDIR SERVER
-for SERVER in `psql $hhconfig_database_name -tc "select display_name from server;"` ; do
-    test -L $SERVER && continue;
-    test -d $SERVER || continue;
-    ls "${SERVER}" | xargs -i --max-procs=$CPUS bash -c "[ -L \"${SERVER}/{}\" ] || ([ -d \"${SERVER}/{}\" ] && cd \"${SERVER}/{}\"; echo \"`date`-->START: ${SERVER}/{}\"; $EXECDIR/dsc-extractor ${ARGS} >> \"${LOG}\" 2>&1; echo \"`date`-->DONE: ${SERVER}/{}\")"
+for SERVER in $(psql "$hhconfig_database_name" -tc "select display_name from server;") ; do
+    [ -L "$SERVER" ] && continue
+    [ -d "$SERVER" ] || continue
+    ls "${SERVER}" | xargs -i --max-procs=$CPUS bash -c "[ -L \"${SERVER}/{}\" ] || ([ -d \"${SERVER}/{}\" ] && cd \"${SERVER}/{}\"; echo \"\$(date) START: ${SERVER}/{}\"; $EXECDIR/dsc-extractor ${ARGS} >> \"${LOG}\" 2>&1; echo \"\$(date) DONE: ${SERVER}/{}\")"
     # use below version instead to skip nodes that don't
     # have an incoming directory.  It is useful if you
     # receive pre-grokked data to this presenter, but
@@ -135,4 +129,4 @@ for SERVER in `psql $hhconfig_database_name -tc "select display_name from server
     # incoming subdirectory
     # ls "${SERVER}" | xargs -i --max-procs=$CPUS bash -c "[ -L \"${SERVER}/{}\" ] || ([ -d \"${SERVER}/{}\" ] && [ -d \"${SERVER}/{}/incoming\" ] && cd \"${SERVER}/{}\"; echo \"`date`-->START: ${SERVER}/{}\"; $EXECDIR/dsc-extractor ${ARGS} >> \"${LOG}\" 2>&1; echo \"`date`-->DONE: ${SERVER}/{}\")"
 done
-echo "`date`-->SCRIPT COMPLETE"
+echo "$(date) SCRIPT COMPLETE"


### PR DESCRIPTION
This set of changes addresses various things:
1. Fixes inconsistent quoting
2. Uses bash features where available, to avoid the "echo | sed" pipe/fork chain
3. Uses features of awk to avoid a long pipeline containing grep/tail
4. Replaces all backticks with $(...) (backticks are deprecated; the script had a mix if backticks and $(...) )
5. Consistent usage of [ ... ] everywhere (instead of a mix of "test" and [ ... ] )
6. Fixes a bug in line 123, where the call to date in backticks was  not escaped, causing the script to report the same start time for all node processing, because the date was being evaluated at the time the script was parsed, instead of at runtime.
7. Deletes some spurious semicolons