### PR TITLE
Update dsc-extractor.cpp

### DIFF
--- a/src/bin/dsc-extractor.cpp
+++ b/src/bin/dsc-extractor.cpp
@@ -22,6 +22,7 @@
 /// a PostgreSQL database. It can also convert from XML to DAT.
 
 #include "config.h"
+#include <iostream>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
iostream is needed for this to compile on older distributions like CentOS 6