### PR TITLE
Update refile_and_grok.sh.in

### DIFF
--- a/tools/refile_and_grok.sh.in
+++ b/tools/refile_and_grok.sh.in
@@ -31,7 +31,7 @@ set -e # exit if any command yields a non 0 exit status
 WD="$hhconfig_directories_data"
 INPUT="XML"
 OUTPUT="DB"
-CONNSTR="dbname=$hhconfig_database_name dbport=$hhconfig_database_port"
+CONNSTR="dbname=$hhconfig_database_name port=$hhconfig_database_port"
 START_DATE=""
 RSSAC_FLAG=""
 RESERVED_CPUS=0


### PR DESCRIPTION
The postgresql documentation at:

http://www.postgresql.org/docs/9.3/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS

suggests that in the connection string, the port is specified with the "port" keyword, and not "dbport".