### PR TITLE
Fix potential sql injection through fs path

### DIFF
--- a/src/DSCIOManager.cpp
+++ b/src/DSCIOManager.cpp
@@ -216,6 +216,7 @@ DSCIOManager::dsc_import_input_from_source() {
     string server = bfs::initial_path().parent_path().filename().generic_string();
     //transform to 'internal' name
     replace(server.begin(), server.end(), '-', '_');
+    replace(server.begin(), server.end(), '\'', '_');
     replace_string(server, ".", "__");
     transform(server.begin(), server.end(), server.begin(), ::tolower);
     

--- a/src/DSCIOManager.cpp
+++ b/src/DSCIOManager.cpp
@@ -214,9 +214,11 @@ DSCIOManager::dsc_import_input_from_source() {
     
     string node = bfs::initial_path().filename().generic_string();
     string server = bfs::initial_path().parent_path().filename().generic_string();
+    //fix potential sql injection
+    replace(node.begin(), node.end(), '\'', '_');
+    replace(server.begin(), server.end(), '\'', '_');
     //transform to 'internal' name
     replace(server.begin(), server.end(), '-', '_');
-    replace(server.begin(), server.end(), '\'', '_');
     replace_string(server, ".", "__");
     transform(server.begin(), server.end(), server.begin(), ::tolower);
     


### PR DESCRIPTION
Hello!

I have found a potential sql injection through fs path. I can't evaluate a risk, but still send a PR.

Flow description:
1. Unsafe path comes from https://github.com/dns-stats/hedgehog/blob/develop/src/DSCIOManager.cpp#L216. Potentially it may be something like `a' or '1' = '1`. This string will successfully inject in sql query further.
2. This parameter goes to initialization of DSCDataManager. https://github.com/dns-stats/hedgehog/blob/develop/src/DSCIOManager.cpp#L235
3. Then raw server_name is used in sql query. https://github.com/dns-stats/hedgehog/blob/develop/src/DSCDataManager.cpp#L307. The same happens with node: https://github.com/dns-stats/hedgehog/blob/develop/src/DSCDataManager.cpp#L341.

I added an escaping of unsafe character. But better fix is to use pqxx builtin escape functions like `quote`.
I was unable to compile the project. So i decided to make a safer fix.

Thanks.
